### PR TITLE
Vector clean up

### DIFF
--- a/src/MutableVector.ts
+++ b/src/MutableVector.ts
@@ -1,24 +1,24 @@
-import {Vector} from "./Vector";
+import {PersistentVector} from "./Vector";
 
 /**
- * A mutable reference to a Vector
+ * A mutable reference to a PersistentVector
  */
 export class MutableVector<T> implements Iterable<T> {
-  private constructor(public vector: Vector<T>) {}
+  private constructor(public vector: PersistentVector<T>) {}
 
   static empty<T>(): MutableVector<T> {
-    return new MutableVector(Vector.empty());
+    return new MutableVector(PersistentVector.empty);
   }
 
   static from<T>(values: Iterable<T>): MutableVector<T> {
-    return new MutableVector(Vector.from(values));
+    return new MutableVector(PersistentVector.from(values));
   }
 
   get length(): number {
     return this.vector.length;
   }
 
-  get(index: number): T | null {
+  get(index: number): T | undefined {
     return this.vector.get(index);
   }
 
@@ -36,7 +36,7 @@ export class MutableVector<T> implements Iterable<T> {
   }
 
   push(value: T): void {
-    this.vector = this.vector.append(value);
+    this.vector = this.vector.push(value);
   }
 
   pop(): T | undefined {
@@ -45,19 +45,23 @@ export class MutableVector<T> implements Iterable<T> {
     return last ?? undefined;
   }
 
-  *[Symbol.iterator](): Generator<T> {
+  *[Symbol.iterator](): IterableIterator<T> {
     yield* this.vector[Symbol.iterator]();
   }
 
   forEach(func: (t: T, i: number) => void): void {
-    this.vector.readOnlyForEach(func);
+    this.vector.forEach(func);
   }
 
   map<T2>(func: (t: T, i: number) => T2): T2[] {
-    return this.vector.readOnlyMap(func);
+    return this.vector.map(func);
   }
 
   clone(): MutableVector<T> {
     return new MutableVector(this.vector);
+  }
+
+  toArray(): T[] {
+    return this.vector.toArray();
   }
 }

--- a/test/perf/Vector.test.ts
+++ b/test/perf/Vector.test.ts
@@ -1,16 +1,21 @@
 import {expect} from "chai";
-import {Vector} from "../../src/Vector";
+import {PersistentVector} from "../../src/Vector";
 
-it("should be able to handle 10M elements", function () {
+it("PersistentVector - should be able to handle 10M elements", function () {
   this.timeout(0);
   let start = Date.now();
-  let acc = Vector.empty<number>();
+  let acc: PersistentVector<number> = PersistentVector.empty;
   const times = 10000000;
   for (let i = 0; i < times; ++i) {
-    acc = acc.append(i);
+    acc = acc.push(i);
   }
   expect(acc.length).to.be.equal(times);
-  console.log(`Finish append ${times} items in`, Date.now() - start);
+  console.log(`Finish push ${times} items in`, Date.now() - start);
+  start = Date.now();
+  for (let i = 0; i < times; ++i) {
+    acc = acc.set(i, i);
+  }
+  console.log(`Finish set ${times} items in`, Date.now() - start);
   start = Date.now();
   let index = 0;
   for (const _ of acc) {
@@ -26,18 +31,18 @@ it("should be able to handle 10M elements", function () {
   // console.log(`Finish regular for of ${times} items in`, Date.now() - start);
   start = Date.now();
   let count = 0;
-  acc.readOnlyForEach(() => {
+  acc.forEach(() => {
     count++;
   });
   expect(count).to.be.equal(times);
-  console.log(`Finish readOnlyForEach of ${times} items in`, Date.now() - start);
+  console.log(`Finish forEach of ${times} items in`, Date.now() - start);
   start = Date.now();
-  const tsArray = acc.toTS();
+  const tsArray = acc.toArray();
   expect(tsArray.length).to.be.equal(times);
-  console.log(`Finish toTS of ${times} items in`, Date.now() - start);
+  console.log(`Finish toArray of ${times} items in`, Date.now() - start);
   start = Date.now();
-  const newArr = acc.readOnlyMap<number>((v) => v * 2);
-  console.log(`Finish readOnlyMap of ${times} items in`, Date.now() - start);
+  const newArr = acc.map<number>((v) => v * 2);
+  console.log(`Finish map of ${times} items in`, Date.now() - start);
   expect(newArr[1]).to.be.equal(2);
   expect(newArr.length).to.be.equal(times);
   start = Date.now();


### PR DESCRIPTION
- Rename `Vector` to `PersistentVector`
- Rename `append` to `push`
- Rename `toTS` to `toArray`
  - `toArray` is significantly faster than `values`, so its used in `[Symbol.iterator]()`
- Refactor `empty` to be a singleton rather than function
- Refactor `INode` type
  - `edit` reference for `TransientVector` (see link below, will come in a separate PR)
- Refactor code to use new `INode` type

Extra Context:
Our implementation almost exactly follows https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/PersistentVector.java but with a more "javascripty" interface (get/set vs lisp-y interface)