### PR TITLE
Add TransientVector

### DIFF
--- a/src/MutableVector.ts
+++ b/src/MutableVector.ts
@@ -1,10 +1,13 @@
-import {PersistentVector} from "./Vector";
+import {PersistentVector, TransientVector} from "./Vector";
 
 /**
- * A mutable reference to a PersistentVector
+ * A mutable reference to a PersistentVector or TransientVector
  */
 export class MutableVector<T> implements Iterable<T> {
-  private constructor(public vector: PersistentVector<T>) {}
+  public vector: PersistentVector<T> | TransientVector<T>;
+  private constructor(vector: PersistentVector<T>) {
+    this.vector = vector;
+  }
 
   static empty<T>(): MutableVector<T> {
     return new MutableVector(PersistentVector.empty);
@@ -12,6 +15,20 @@ export class MutableVector<T> implements Iterable<T> {
 
   static from<T>(values: Iterable<T>): MutableVector<T> {
     return new MutableVector(PersistentVector.from(values));
+  }
+
+  asTransient(): this {
+    if ((this.vector as PersistentVector<T>).asTransient) {
+      this.vector = (this.vector as PersistentVector<T>).asTransient();
+    }
+    return this;
+  }
+
+  asPersistent(): this {
+    if ((this.vector as TransientVector<T>).persistent) {
+      this.vector = (this.vector as TransientVector<T>).persistent();
+    }
+    return this;
   }
 
   get length(): number {
@@ -58,7 +75,8 @@ export class MutableVector<T> implements Iterable<T> {
   }
 
   clone(): MutableVector<T> {
-    return new MutableVector(this.vector);
+    this.asPersistent();
+    return new MutableVector(this.vector as PersistentVector<T>);
   }
 
   toArray(): T[] {

--- a/src/Vector.ts
+++ b/src/Vector.ts
@@ -35,6 +35,11 @@ function copyNode<T>(node: INode<T>): INode<T> {
   return {edit: node.edit, array: [...node.array] as (INode<T> | undefined)[]};
 }
 
+function ensureEditable<T>(node: INode<T>, edit: {ref: boolean}): INode<T> {
+  if (node.edit === edit) return node;
+  else return {edit, array: [...node.array] as (INode<T> | undefined)[]};
+}
+
 /**
  * A PersistentVector is a collection of values indexed by contiguous integers.
  * PersistentVectors support access to items by index in log32N hops.
@@ -64,9 +69,13 @@ export class PersistentVector<T> implements Iterable<T> {
    * @param values the values that this vector will contain
    */
   static from<T>(values: Iterable<T>): PersistentVector<T> {
-    let acc = PersistentVector.empty;
+    let acc = PersistentVector.empty.asTransient();
     for (const v of values) acc = acc.push(v);
-    return acc;
+    return acc.persistent();
+  }
+
+  asTransient(): TransientVector<T> {
+    return new TransientVector(ensureEditable(this.root, {ref: true}), this.shift, [...this.tail], this.length);
   }
 
   /**
@@ -285,6 +294,273 @@ export class PersistentVector<T> implements Iterable<T> {
    */
   clone(): PersistentVector<T> {
     return new PersistentVector(this.root, this.shift, this.tail, this.length);
+  }
+
+  private getTailLength(): number {
+    return this.length - this.getTailOffset();
+  }
+
+  /**
+   * Returns the first index of the tail, also the number of the leaf elements in the tree
+   */
+  private getTailOffset(): number {
+    return this.length < BRANCH_SIZE ? 0 : ((this.length - 1) >>> BIT_WIDTH) << BIT_WIDTH;
+  }
+}
+
+/**
+ * A TransientVector is a collection of values indexed by contiguous integers.
+ * TransientVectors support access to items by index in log32N hops.
+ */
+export class TransientVector<T> implements Iterable<T> {
+  constructor(private root: INode<T>, private shift: number, private tail: T[], readonly length: number) {}
+
+  /**
+   * The empty vector
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static empty<T>(): TransientVector<T> {
+    return new TransientVector<T>(emptyNode({ref: true}), DEFAULT_LEVEL_SHIFT, Array(BRANCH_SIZE).fill(undefined), 0);
+  }
+
+  /**
+   * Create a new vector containing certain elements.
+   *
+   * @param values the values that this vector will contain
+   */
+  static from<T>(values: Iterable<T>): TransientVector<T> {
+    let acc = TransientVector.empty<T>();
+    for (const v of values) acc = acc.push(v);
+    return acc;
+  }
+
+  ensureEditable(): void {
+    if (!this.root.edit.ref) {
+      throw new Error("Transient used after persistent call");
+    }
+  }
+
+  persistent(): PersistentVector<T> {
+    this.ensureEditable();
+    this.root.edit.ref = false;
+    const trimmedTail = this.tail.slice(0, this.getTailLength());
+    return new PersistentVector(this.root, this.shift, trimmedTail, this.length);
+  }
+
+  /**
+   * O(log_32(N)) Return the value at a certain index, if it exists.
+   *
+   * Returns `undefined` if the index is out of the vector's bounds.
+   *
+   * @param index the index to look up
+   */
+  get(index: number): T | undefined {
+    if (index < 0 || index >= this.length) return undefined;
+
+    let array;
+    if (index >= this.getTailOffset()) {
+      array = this.tail;
+    } else {
+      let cursor: INode<T> = this.root;
+      for (let level = this.shift; level > 0; level -= BIT_WIDTH) {
+        // This cast is fine because we checked the length prior
+        cursor = cursor.array[(index >>> level) & BIT_MASK] as INode<T>;
+      }
+      array = cursor.array;
+    }
+    return array[index & BIT_MASK] as T;
+  }
+
+  /**
+   * O(log_32(N)) Return a new vector with an element set to a new value.
+   *
+   * This will do nothing if the index is negative, or out of the bounds of the vector.
+   *
+   * @param index the index to set
+   * @param value the value to set at that index
+   */
+  set(index: number, value: T): TransientVector<T> {
+    this.ensureEditable();
+    if (index < 0 || index >= this.length) return this;
+    if (index >= this.getTailOffset()) {
+      this.tail[index & BIT_MASK] = value;
+      // The element is updated in the tail
+      // The root is not changed
+      return this;
+    }
+    let cursor: INode<T> = this.root;
+    for (let level = this.shift; level > 0; level -= BIT_WIDTH) {
+      const subIndex = (index >>> level) & BIT_MASK;
+      // This cast is fine because we checked the length prior
+      const next: INode<T> = ensureEditable(cursor.array[subIndex] as INode<T>, this.root.edit);
+      cursor.array[subIndex] = next;
+      cursor = next;
+    }
+    cursor.array[index & BIT_MASK] = value;
+    // tail is not changed
+    return this;
+  }
+
+  /**
+   * O(log_32(N)) Append a value to the end of this vector.
+   *
+   * This is useful for building up a vector from values.
+   *
+   * @param value the value to push to the end of the vector
+   */
+  push(value: T): TransientVector<T> {
+    this.ensureEditable();
+    if (this.getTailLength() < BRANCH_SIZE) {
+      // has space in tail
+      this.tail[this.length % BRANCH_SIZE] = value;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.length += 1;
+      // The element is added to the tail
+      // The root is not changed
+      return this;
+    }
+    // There's not enough space in the tail
+    if (isFullBranch(this.length - BRANCH_SIZE)) {
+      const base: INode<T> = emptyNode(this.root.edit);
+      base.array[0] = this.root;
+      this.shift += BIT_WIDTH;
+      this.root = base;
+    }
+    // getTailOffset is actually the 1st item in tail
+    // we now move it to the tree
+    const index = this.getTailOffset();
+    let cursor: INode<T> = this.root;
+    for (let level = this.shift; level > 0; level -= BIT_WIDTH) {
+      const subIndex = (index >>> level) & BIT_MASK;
+      let next: INode<T> | undefined = cursor.array[subIndex] as IBranch<T>;
+      if (!next) {
+        next = emptyNode(this.root.edit);
+      } else {
+        next = ensureEditable(next, this.root.edit);
+      }
+      cursor.array[subIndex] = next;
+      cursor = next;
+    }
+    // it's safe to update cursor bc "next" is a new instance anyway
+    cursor.array = this.tail;
+    this.tail = [value, ...(Array(BRANCH_SIZE - 1).fill(undefined) as T[])];
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    this.length += 1;
+    return this;
+  }
+
+  /**
+   * Return a new Vector with the last element removed.
+   *
+   * This does nothing if the Vector contains no elements.
+   */
+  pop(): TransientVector<T> {
+    this.ensureEditable();
+    if (this.length === 0) return this;
+    // we always have a non-empty tail
+    const tailLength = this.getTailLength();
+    if (tailLength >= 2) {
+      delete this.tail[tailLength - 1];
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.length -= 1;
+      return this;
+    }
+    // tail has exactly 1 item, promote the right most leaf node as tail
+    const lastItemIndexInTree = this.getTailOffset() - 1;
+    // Tree has no item
+    if (lastItemIndexInTree < 0) {
+      return TransientVector.empty<T>();
+    }
+    let cursor: INode<T> = this.root;
+    // we always have a parent bc we create an empty branch initially
+    let parent: INode<T> | undefined = undefined;
+    let subIndex: number;
+    for (let level = this.shift; level > 0; level -= BIT_WIDTH) {
+      subIndex = (lastItemIndexInTree >>> level) & BIT_MASK;
+      // This cast is fine because we checked the length prior
+      const next: INode<T> = ensureEditable(cursor.array[subIndex] as INode<T>, this.root.edit);
+      cursor.array[subIndex] = next;
+      parent = cursor;
+      cursor = next;
+    }
+    this.tail = cursor.array as T[];
+    parent!.array[subIndex!] = emptyNode<T>(this.root.edit);
+
+    if (isFullBranch(this.length - 1 - BRANCH_SIZE)) {
+      this.root = this.root.array[0] as IBranch<T>;
+      this.shift -= BIT_WIDTH;
+    }
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    this.length -= 1;
+    return this;
+  }
+
+  *keys(): IterableIterator<number> {
+    yield* Array.from({length: this.length}, (_, i) => i);
+  }
+
+  *values(): IterableIterator<T> {
+    function* iterateNodeValues(node: INode<T>, level: number): Iterable<T> {
+      if (level <= 0) {
+        yield* (node as ILeaf<T>).array.filter((i) => i != null);
+      } else {
+        for (const child of (node as IBranch<T>).array.filter((i) => i != null)) {
+          yield* iterateNodeValues(child as INode<T>, level - BIT_WIDTH);
+        }
+      }
+    }
+    yield* iterateNodeValues(this.root, this.shift);
+    yield* this.tail.slice(0, this.getTailLength());
+  }
+
+  /**
+   * Implement Iterable interface.
+   */
+  *[Symbol.iterator](): IterableIterator<T> {
+    yield* this.toArray();
+  }
+
+  /**
+   */
+  forEach(func: (t: T, i: number) => void): void {
+    this.toArray().forEach(func);
+  }
+
+  /**
+   * Map to an array of T2.
+   */
+  map<T2>(func: (t: T, i: number) => T2): T2[] {
+    return this.toArray().map(func);
+  }
+
+  /**
+   * Convert to regular typescript array
+   */
+  toArray(): T[] {
+    const values: T[] = [];
+    function iterateNodeValues(node: INode<T>, level: number): void {
+      if (level <= 0) {
+        values.push(...(node as ILeaf<T>).array.filter((i) => i != null));
+      } else {
+        for (const child of (node as IBranch<T>).array.filter((i) => i != null)) {
+          iterateNodeValues(child as INode<T>, level - BIT_WIDTH);
+        }
+      }
+    }
+    iterateNodeValues(this.root, this.shift);
+    values.push(...this.tail.slice(0, this.getTailLength()));
+    return values;
+  }
+
+  /**
+   * Clone to a new vector.
+   */
+  clone(): TransientVector<T> {
+    return new TransientVector(this.root, this.shift, this.tail, this.length);
   }
 
   private getTailLength(): number {

--- a/test/perf/Vector.test.ts
+++ b/test/perf/Vector.test.ts
@@ -1,10 +1,60 @@
 import {expect} from "chai";
-import {PersistentVector} from "../../src/Vector";
+import {PersistentVector, TransientVector} from "../../src/Vector";
 
 it("PersistentVector - should be able to handle 10M elements", function () {
   this.timeout(0);
   let start = Date.now();
   let acc: PersistentVector<number> = PersistentVector.empty;
+  const times = 10000000;
+  for (let i = 0; i < times; ++i) {
+    acc = acc.push(i);
+  }
+  expect(acc.length).to.be.equal(times);
+  console.log(`Finish push ${times} items in`, Date.now() - start);
+  start = Date.now();
+  for (let i = 0; i < times; ++i) {
+    acc = acc.set(i, i);
+  }
+  console.log(`Finish set ${times} items in`, Date.now() - start);
+  start = Date.now();
+  let index = 0;
+  for (const _ of acc) {
+    // expect(item).to.be.equal(index);
+    index++;
+  }
+  expect(index).to.be.equal(times);
+  console.log(`Finish regular iterator ${times} in`, Date.now() - start);
+  // start = Date.now();
+  // for (let i = 0; i < times; ++i) {
+  //   expect(acc.get(i)).to.be.equal(i);
+  // }
+  // console.log(`Finish regular for of ${times} items in`, Date.now() - start);
+  start = Date.now();
+  let count = 0;
+  acc.forEach(() => {
+    count++;
+  });
+  expect(count).to.be.equal(times);
+  console.log(`Finish forEach of ${times} items in`, Date.now() - start);
+  start = Date.now();
+  const tsArray = acc.toArray();
+  expect(tsArray.length).to.be.equal(times);
+  console.log(`Finish toArray of ${times} items in`, Date.now() - start);
+  start = Date.now();
+  const newArr = acc.map<number>((v) => v * 2);
+  console.log(`Finish map of ${times} items in`, Date.now() - start);
+  expect(newArr[1]).to.be.equal(2);
+  expect(newArr.length).to.be.equal(times);
+  start = Date.now();
+  const newArr2 = tsArray.map((v) => v * 2);
+  console.log(`Finish regular map of regular array of ${times} items in`, Date.now() - start);
+  expect(newArr).to.be.deep.equal(newArr2);
+});
+
+it("TransientVector - should be able to handle 10M elements", function () {
+  this.timeout(0);
+  let start = Date.now();
+  let acc: TransientVector<number> = TransientVector.empty();
   const times = 10000000;
   for (let i = 0; i < times; ++i) {
     acc = acc.push(i);


### PR DESCRIPTION
Implementation of `TransientVector` as in  https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/PersistentVector.java

`TransientVector` has the same interface as `PersistentVector`, but the implementation is slightly different: it doesn't create a new copy when edited.

Converting between transient and persistent is done with `TransientVector#persistent` and `PersistentVector#asTransient`.
Once a `TransientVector` has called the `persistent` method to return a `PersistentVector`, the transient vector can no longer be used.

`MutableVector` has been extended to be backed by _either_ a Persistent or Transient vector. The backing implementation can be toggled with the `asTransient` and `asPersistent` methods.